### PR TITLE
Feat: add js scope config

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,4 +173,7 @@ jsx:
       - 'title2'
 ```
 
- **_Note:_** You can use the [IBM Telemetry Js Config Generator](https://www.npmjs.com/package/@ibm/telemetry-js-config-generator) script to automatically generate a config file with these values. Remember to verify that the generated output is correct before using the config file.
+**_Note:_** You can use the
+[IBM Telemetry Js Config Generator](https://www.npmjs.com/package/@ibm/telemetry-js-config-generator)
+script to automatically generate a config file with these values. Remember to verify that the
+generated output is correct before using the config file.

--- a/README.md
+++ b/README.md
@@ -172,3 +172,5 @@ jsx:
       - 'title1'
       - 'title2'
 ```
+
+ **_Note:_** You can use the [IBM Telemetry Js Config Generator](https://www.npmjs.com/package/@ibm/telemetry-js-config-generator) script to automatically generate a config file with these values. Remember to verify that the generated output is correct before using the config file.

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -70,5 +70,29 @@ export interface ConfigSchema {
         allowedAttributeStringValues?: [string, ...string[]]
       }
     }
+    /**
+     * Configuration for collecting telemetry data from JS files.
+     *
+     * @minProperties 1
+     */
+    js?: {
+      /**
+       * Enable telemetry data collection for JS tokens. The set of included tokens is
+       * determined by looking at import/require statements across analyzed source files.
+       */
+      tokens?: null
+      /**
+       * Enable telemetry data collection for JS functions. The set of included functions is
+       * determined by looking at import/require statements across analyzed source files.
+       */
+      functions?: {
+        /**
+         * Enable telemetry data collection for specific string function argument values.
+         * These are collected for all included functions.
+         * Boolean and numeric values are collected by default.
+         */
+        allowedArgumentStringValues?: [string, ...string[]]
+      }
+    }
   }
 }

--- a/src/test/test.yml
+++ b/src/test/test.yml
@@ -11,7 +11,7 @@ collect:
         - 'one'
         - 'two'
   js:
-    functions: 
+    functions:
       allowedArgumentStringValues:
         - 'three'
     tokens: null

--- a/src/test/test.yml
+++ b/src/test/test.yml
@@ -10,3 +10,8 @@ collect:
       allowedAttributeStringValues:
         - 'one'
         - 'two'
+  js:
+    functions: 
+      allowedArgumentStringValues:
+        - 'three'
+    tokens: null


### PR DESCRIPTION
Adds function and token config options for JS scope according to [tech design ](https://github.com/ibm-telemetry/telemetry-internal/blob/main/tech-designs/td-10-js-scope-tokens-and-functions.md#telemetryyml-config-file-extensions)

#### Changelog

**New**

- JS key in schema, including `tokens`, `functions` and `allowedArgumentStringValues` keys.
- Add Telemetry config script reference to. README


#### Testing / reviewing

See `src/test/test.yml`
