### PR TITLE
chore: update copyright notices for telemetry-config-schema

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.copyright.js
+++ b/.copyright.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. <%= YEAR %>, 2024
+ * Copyright IBM Corp. <%= YEAR %>, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -136,7 +136,7 @@ module.exports = {
     ],
     'n/shebang': 'off',
     'notice/notice': [
-      'warn',
+      'error',
       {
         templateFile: path.join(__dirname, '.copyright.js')
       }

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/scripts/format-package-json.js
+++ b/scripts/format-package-json.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2022, 2024
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Closes ibm-telemetry/telemetry-internal#284

#### Changelog

**Changed**

- eslint copyright notice rule changed from warning to error
- updated notice template to current year 2025
- updated current year to 2025 in all existing source file notices

#### Testing / reviewing

- all source file notices should be properly updated
- newly created files should have proper notice added when `npm run lint:fix` runs